### PR TITLE
Create Codec Factories / No More `new`

### DIFF
--- a/array.test.ts
+++ b/array.test.ts
@@ -4,9 +4,9 @@ import * as asserts from "std/testing/asserts.ts";
 
 Deno.test("Arrays", () => {
   fixtures.array_().forEach(([decoded, encoded, sizedEncoded]: [any[], Uint8Array, Uint8Array]) => {
-    asserts.assertEquals(new s.Array(s.u8).decode(encoded), decoded);
-    asserts.assertEquals(new s.Array(s.u8).encode(decoded), encoded);
-    asserts.assertEquals(new s.SizedArray(s.u8, decoded.length).decode(sizedEncoded), decoded);
-    asserts.assertEquals(new s.SizedArray(s.u8, decoded.length).encode(decoded), sizedEncoded);
+    asserts.assertEquals(s.array(s.u8).decode(encoded), decoded);
+    asserts.assertEquals(s.array(s.u8).encode(decoded), encoded);
+    asserts.assertEquals(s.sizedArray(s.u8, decoded.length).decode(sizedEncoded), decoded);
+    asserts.assertEquals(s.sizedArray(s.u8, decoded.length).encode(decoded), sizedEncoded);
   });
 });

--- a/array.ts
+++ b/array.ts
@@ -37,6 +37,15 @@ export class SizedArray<
     );
   }
 }
+export const sizedArray = <
+  ElCodec extends Codec,
+  Len extends number,
+>(
+  elCodec: ElCodec,
+  len: Len,
+): SizedArray<ElCodec, Len> => {
+  return new SizedArray(elCodec, len);
+};
 
 export class Array<ElCodec extends Codec> extends Codec<NativeArray<ElCodec>> {
   constructor(elCodec: ElCodec) {
@@ -54,3 +63,6 @@ export class Array<ElCodec extends Codec> extends Codec<NativeArray<ElCodec>> {
     );
   }
 }
+export const array = <ElCodec extends Codec>(elCodec: ElCodec): Array<ElCodec> => {
+  return new Array(elCodec);
+};

--- a/dummy.ts
+++ b/dummy.ts
@@ -5,7 +5,7 @@ import { Codec, Native } from "/common.ts";
  * @param value The native value corresponding to the generically-supplied codec
  * @returns A dummy codec with the patched signature of `E`
  */
-export const Dummy = <E extends Codec>(value: Native<E>): E => {
+export const dummy = <E extends Codec>(value: Native<E>): E => {
   return new Codec(
     (_value) => {
       return 0;

--- a/option.test.ts
+++ b/option.test.ts
@@ -4,7 +4,7 @@ import * as asserts from "std/testing/asserts.ts";
 
 Deno.test("Options", () => {
   f.visitFixtures(f.fixtures.option_, (bytes, decoded, i) => {
-    const o = new s.Option(
+    const o = s.option(
       {
         0: s.str,
         1: s.u8,

--- a/option.ts
+++ b/option.ts
@@ -1,17 +1,17 @@
 import { Codec, Native } from "/common.ts";
 import { u8 } from "/int.ts";
 
-export class Option<Some extends Codec> extends Codec<Native<Some> | undefined> {
-  constructor(readonly some: Some) {
+export class Option<SomeCodec extends Codec> extends Codec<Native<SomeCodec> | undefined> {
+  constructor(readonly someCodec: SomeCodec) {
     super(
       (value) => {
-        return value ? some._s(value) + 1 : 1;
+        return value ? someCodec._s(value) + 1 : 1;
       },
       (cursor, value) => {
         cursor.view.setUint8(cursor.i, Number(!!value));
         cursor.i++;
         if (value) {
-          some._e(cursor, value);
+          someCodec._e(cursor, value);
         }
       },
       (cursor) => {
@@ -20,10 +20,13 @@ export class Option<Some extends Codec> extends Codec<Native<Some> | undefined> 
             return undefined;
           }
           case 1: {
-            return some._d(cursor);
+            return someCodec._d(cursor);
           }
         }
       },
     );
   }
 }
+export const option = <SomeCodec extends Codec>(someCodec: SomeCodec): Option<SomeCodec> => {
+  return new Option(someCodec);
+};

--- a/record.test.ts
+++ b/record.test.ts
@@ -3,11 +3,11 @@ import * as f from "/test-util.ts";
 import * as asserts from "std/testing/asserts.ts";
 
 Deno.test("Records", () => {
-  const c = new s.Record(
-    new s.RecordField("name", s.str),
-    new s.RecordField("nickName", s.str),
-    new s.RecordField("superPower", new s.Option(s.str)),
-    new s.RecordField("luckyNumber", s.u8),
+  const c = s.record(
+    s.recordField("name", s.str),
+    s.recordField("nickName", s.str),
+    s.recordField("superPower", s.option(s.str)),
+    s.recordField("luckyNumber", s.u8),
   );
   f.visitFixtures(f.fixtures.record_, (bytes, decoded) => {
     asserts.assertEquals(c.decode(bytes), decoded);

--- a/record.ts
+++ b/record.ts
@@ -34,6 +34,15 @@ export class RecordField<
     );
   }
 }
+export const recordField = <
+  Key extends PropertyKey = PropertyKey,
+  ValueCodec extends Codec = Codec,
+>(
+  key: Key,
+  valueCodec: ValueCodec,
+): RecordField<Key, ValueCodec> => {
+  return new RecordField(key, valueCodec);
+};
 
 export class Record<FieldCodecs extends RecordField[] = RecordField[]> extends Codec<NativeRecord<FieldCodecs>> {
   constructor(...fieldCodecs: FieldCodecs) {
@@ -59,3 +68,6 @@ export class Record<FieldCodecs extends RecordField[] = RecordField[]> extends C
     );
   }
 }
+export const record = <FieldCodecs extends RecordField[]>(...fieldCodecs: FieldCodecs): Record<FieldCodecs> => {
+  return new Record(...fieldCodecs);
+};

--- a/result.ts
+++ b/result.ts
@@ -1,6 +1,8 @@
 import { Codec, Native } from "/common.ts";
 import { Union } from "/union.ts";
 
+// TODO: extract `Instance` codec that allows instantiation of a supplied ctor
+
 export interface DataBearer<D> {
   data: D;
 }

--- a/tuple.test.ts
+++ b/tuple.test.ts
@@ -4,7 +4,7 @@ import * as asserts from "std/testing/asserts.ts";
 
 Deno.test("Tuples", () => {
   f.visitFixtures(f.fixtures.tuple_, (bytes, decoded, i) => {
-    const t = new s.Tuple(
+    const t = s.tuple(
       ...{
         0: [s.str, s.u8, s.str, s.u32],
         1: [s.str, s.i16, new s.Option(s.u16)],

--- a/tuple.ts
+++ b/tuple.ts
@@ -1,14 +1,14 @@
 import { Codec } from "/common.ts";
 
-export type NativeTuple<Els extends Codec[]> = {
-  [I in keyof Els]: NativeTuple._0<Els[I]>;
+export type NativeTuple<ElCodecs extends Codec[]> = {
+  [I in keyof ElCodecs]: NativeTuple._0<ElCodecs[I]>;
 };
 namespace NativeTuple {
   export type _0<I> = I extends Codec<infer T> ? T : I;
 }
 
-export class Tuple<ElementCodecs extends Codec[] = Codec[]> extends Codec<NativeTuple<ElementCodecs>> {
-  constructor(...elCodecs: ElementCodecs) {
+export class Tuple<ElCodecs extends Codec[] = Codec[]> extends Codec<NativeTuple<ElCodecs>> {
+  constructor(...elCodecs: ElCodecs) {
     super(
       (value) => {
         let size = 0;
@@ -26,8 +26,12 @@ export class Tuple<ElementCodecs extends Codec[] = Codec[]> extends Codec<Native
       (cursor) => {
         return elCodecs.map((elCodec) => {
           return elCodec._d(cursor);
-        }) as NativeTuple<ElementCodecs>;
+        }) as NativeTuple<ElCodecs>;
       },
     );
   }
 }
+
+export const tuple = <ElCodecs extends Codec[]>(...elCodecs: ElCodecs): Tuple<ElCodecs> => {
+  return new Tuple(...elCodecs);
+};

--- a/union.test.ts
+++ b/union.test.ts
@@ -3,17 +3,17 @@ import * as f from "/test-util.ts";
 import * as asserts from "std/testing/asserts.ts";
 
 Deno.test("Unions", () => {
-  const c = new s.TaggedUnion(
-    new s.TaggedUnionMember("A"),
-    new s.TaggedUnionMember("B", new s.RecordField("B", s.str)),
-    new s.TaggedUnionMember("C", new s.RecordField("C", new s.Tuple(s.u32, s.u64))),
-    new s.TaggedUnionMember(
+  const c = s.taggedUnion(
+    s.taggedUnionMember("A"),
+    s.taggedUnionMember("B", s.recordField("B", s.str)),
+    s.taggedUnionMember("C", s.recordField("C", s.tuple(s.u32, s.u64))),
+    s.taggedUnionMember(
       "D",
-      new s.RecordField(
+      s.recordField(
         "D",
-        new s.Record(
-          new s.RecordField("a", s.u32),
-          new s.RecordField("b", s.u64),
+        s.record(
+          s.recordField("a", s.u32),
+          s.recordField("b", s.u64),
         ),
       ),
     ),

--- a/union.ts
+++ b/union.ts
@@ -1,5 +1,5 @@
 import { Codec, Native } from "/common.ts";
-import { Dummy } from "/dummy.ts";
+import { dummy } from "/dummy.ts";
 import { u8 } from "/int.ts";
 import { Record, RecordField } from "/record.ts";
 
@@ -28,6 +28,12 @@ export class Union<MemberCodecs extends Codec[]> extends Codec<NativeUnion<Membe
     );
   }
 }
+export const union = <MemberCodecs extends Codec[]>(
+  discriminate: (value: NativeUnion<MemberCodecs>) => number,
+  ...memberCodecs: MemberCodecs
+): Union<MemberCodecs> => {
+  return new Union(discriminate, ...memberCodecs);
+};
 
 export class TaggedUnionMember<
   MemberTag extends PropertyKey = PropertyKey,
@@ -38,11 +44,21 @@ export class TaggedUnionMember<
     ...fieldCodec: FieldCodecs
   ) {
     super(
-      new RecordField("_tag", Dummy(memberTag)),
+      new RecordField("_tag", dummy(memberTag)),
       ...fieldCodec,
     );
   }
 }
+
+export const taggedUnionMember = <
+  MemberTag extends PropertyKey = PropertyKey,
+  FieldCodecs extends RecordField[] = RecordField[],
+>(
+  memberTag: MemberTag,
+  ...fieldCodecs: FieldCodecs
+): TaggedUnionMember<MemberTag, FieldCodecs> => {
+  return new TaggedUnionMember(memberTag, ...fieldCodecs);
+};
 
 // TODO: get rid of contravariant incompatibility without typing member constraint tags as `any`
 export class TaggedUnion<MemberCodecs extends TaggedUnionMember<any>[] = TaggedUnionMember<any>[]>
@@ -57,3 +73,9 @@ export class TaggedUnion<MemberCodecs extends TaggedUnionMember<any>[] = TaggedU
     );
   }
 }
+// TODO: same thing here
+export const taggedUnion = <MemberCodecs extends TaggedUnionMember<any>[]>(
+  ...memberCodecs: MemberCodecs
+): TaggedUnion<MemberCodecs> => {
+  return new TaggedUnion(...memberCodecs);
+};


### PR DESCRIPTION
Per @raoulmillais's recommendation, this PR introduces factories for less bloated instantiation of parent codecs.