### PR TITLE
Create Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: CI
+on:
+  release:
+    types:
+      - created
+jobs:
+  publish:
+    name: Build, Test & Publish to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - name: Build Fixtures
+        run: deno task build_fixtures
+      - name: Test
+        run: deno task test
+      - name: Retrieve Version
+        if: startsWith(github.ref, 'refs/tags/')
+        id: get_tag_version
+        run: echo ::set-output name=TAG_VERSION::${GITHUB_REF/refs\/tags\//}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Build NPM Package
+        run: deno run -A --no-check=remote ./_tasks/build_npm_pkg.ts ${{steps.get_tag_version.outputs.TAG_VERSION}}
+      - name: Publish NPM Package
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: cd target/npm_pkg && npm publish

--- a/_tasks/build_npm_pkg.ts
+++ b/_tasks/build_npm_pkg.ts
@@ -1,13 +1,17 @@
+import { emptyDir } from "std/fs/mod.ts";
 import { build } from "x/dnt/mod.ts";
+
+await emptyDir("target/npm_pkg");
 
 const DESCRIPTION = "SCALE Transcoding in TypeScript";
 
 await build({
   entryPoints: ["mod.ts"],
-  outDir: "target/npm",
+  outDir: "target/npm_pkg",
   package: {
-    name: "scale",
-    version: "0.1.0-beta.1",
+    // TODO: rename if/when we get access to `scale` package name
+    name: "scale-ts",
+    version: Deno.args[0]!,
     description: DESCRIPTION,
   },
   shims: {},

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -8,7 +8,7 @@
   },
   "lint": {
     "files": {
-      "exclude": ["npm"],
+      "exclude": ["target"],
       "include": ["."]
     },
     "rules": {
@@ -28,7 +28,7 @@
     "build_wasm": "cargo build --release --target wasm32-unknown-unknown",
     "build_wasm_bindings": "wasm-bindgen target/wasm32-unknown-unknown/release/scale_fixtures.wasm --target deno --weak-refs --out-dir target/fixtures",
     "build_fixtures": "deno task build_wasm && deno task build_wasm_bindings",
-    "build_npm": "deno run -A --no-check=remote tasks/npm.ts",
+    "build_npm_pkg": "deno run -A --no-check=remote _tasks/build_npm_pkg.ts",
     "test": "deno test -A --no-check=remote -L=info"
   }
 }

--- a/words.txt
+++ b/words.txt
@@ -10,3 +10,4 @@ magz
 deno
 combinators
 typeof
+denoland


### PR DESCRIPTION
We'll be using GitHub's built-in release drafting. When a release occurs, the `release` workflow will check out the repo, ensure all tests are passing, grab the new tag version, build the code (thanks to [DNT](https://github.com/denoland/dnt)) and perform an NPM publish. Version numbers are NOT stored in this repository. Approach recommended [here](https://github.com/denoland/automation/issues/20).