### PR TITLE
allow tag key to be specified for tagged unions

### DIFF
--- a/tagged_union.test.ts
+++ b/tagged_union.test.ts
@@ -4,6 +4,7 @@ import * as f from "./test-util.ts";
 
 Deno.test("Unions", () => {
   const c = s.taggedUnion(
+    "_tag",
     ["A"],
     ["B", ["B", s.str]],
     ["C", ["C", s.tuple(s.u32, s.u64)]],

--- a/tagged_union.ts
+++ b/tagged_union.ts
@@ -9,41 +9,53 @@ export type TaggedUnionMember<
   MemberEntryValueCodec extends Codec = Codec,
 > = [MemberTag, ...Field<MemberEntryKey, MemberEntryValueCodec>[]];
 
-export type NativeTaggedUnionMember<M extends TaggedUnionMember> =
-  & { _tag: M[0] }
+export type NativeTaggedUnionMember<
+  TagKey extends PropertyKey,
+  M extends TaggedUnionMember,
+> =
+  & { [_ in TagKey]: M[0] }
   & (M extends [any, ...infer R] ? R extends Field[] ? NativeRecord<R> : {} : never);
 
-export type NativeTaggedUnionMembers<M extends TaggedUnionMember[]> = M extends [] ? never
+export type NativeTaggedUnionMembers<
+  TagKey extends PropertyKey,
+  M extends TaggedUnionMember[],
+> = M extends [] ? never
   : M extends [infer E0, ...infer ERest] ?
-    | (E0 extends TaggedUnionMember ? NativeTaggedUnionMember<E0> : never)
-    | (ERest extends TaggedUnionMember[] ? NativeTaggedUnionMembers<ERest> : never)
+    | (E0 extends TaggedUnionMember ? NativeTaggedUnionMember<TagKey, E0> : never)
+    | (ERest extends TaggedUnionMember[] ? NativeTaggedUnionMembers<TagKey, ERest> : never)
   : never;
-namespace NativeTaggedUnionMembers {
-  export type _0<T> = T extends TaggedUnionMember ? NativeTaggedUnionMember<T> : T;
-}
 
-export class TaggedUnion<Members extends TaggedUnionMember[]> extends Union<NativeTaggedUnionMembers<Members>[]> {
-  constructor(...members: Members) {
+export class TaggedUnion<
+  TagKey extends PropertyKey,
+  Members extends TaggedUnionMember[],
+> extends Union<NativeTaggedUnionMembers<TagKey, Members>[]> {
+  constructor(
+    tagKey: TagKey,
+    ...members: Members
+  ) {
     super(
       (value) => {
         return members.findIndex((member) => {
-          // TODO: variadic `NativeTaggedUnionMembers` makes presence of `_tag` inaccessible? Investigate.
-          return member[0] === (value as any)._tag;
+          return member[0] === value[tagKey];
         });
       },
       ...members.map(([memberTag, ...fields]) => {
         return record(["_tag", dummy(memberTag)], ...fields || []);
-        // TODO: investigate
+        // TODO: investigate alternatives
       }) as any[],
     );
   }
 }
 
 export const taggedUnion = <
+  TagKey extends PropertyKey,
   Members extends TaggedUnionMember<MemberTag, MemberEntryKey, MemberEntryValueCodec>[],
   MemberTag extends PropertyKey,
   MemberEntryKey extends PropertyKey,
   MemberEntryValueCodec extends Codec,
->(...members: Members): TaggedUnion<Members> => {
-  return new TaggedUnion(...members);
+>(
+  tagKey: TagKey,
+  ...members: Members
+): TaggedUnion<TagKey, Members> => {
+  return new TaggedUnion(tagKey, ...members);
 };


### PR DESCRIPTION
Fixes #18 

Allows for the developer to specify the desired tag of a tagged union.

```diff
const c = s.taggedUnion(
+ "_tag",
  ["A"],
  ["B", ["B", s.str]],
  ["C", ["C", s.tuple(s.u32, s.u64)]],
);
```