### PR TITLE
Instance Codec

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -239,14 +239,16 @@ A common use case for `Instance` codecs is `Error` subtypes. Let's say we want t
 ```ts
 class MyError extends Error {
   constructor(
-    code: string,
-    message: string,
-    payload: {
+    readonly code: number,
+    readonly message: string,
+    readonly payload: {
       a: string;
       b: number;
       c: boolean;
     },
-  ) {}
+  ) {
+    super();
+  }
 }
 ```
 
@@ -255,7 +257,7 @@ We can do so as follows.
 ```ts
 const codec = s.instance(
   MyError,
-  ["code", s.str],
+  ["code", s.u8],
   ["message", s.str],
   [
     "payload",

--- a/instance.test.ts
+++ b/instance.test.ts
@@ -1,0 +1,45 @@
+import * as asserts from "std/testing/asserts.ts";
+import * as s from "./mod.ts";
+
+Deno.test("Instances", () => {
+  class MyError extends Error {
+    constructor(
+      readonly code: number,
+      readonly message: string,
+      readonly payload: {
+        a: string;
+        b: number;
+        c: boolean;
+      },
+    ) {
+      super();
+    }
+  }
+  const c = s.instance(
+    MyError,
+    ["code", s.u8],
+    ["message", s.str],
+    [
+      "payload",
+      s.record(
+        ["a", s.str],
+        ["b", s.u8],
+        ["c", s.bool],
+      ),
+    ],
+  );
+  const myErr = new MyError(
+    1,
+    "At war with my Arch system config",
+    {
+      a: "a",
+      b: 2,
+      c: true,
+    },
+  );
+  const myErrEncoded = c.encode(myErr);
+  const myErrDecoded = c.decode(myErrEncoded);
+  asserts.assertEquals(myErr.code, myErrDecoded.code);
+  asserts.assertEquals(myErr.message, myErrDecoded.message);
+  asserts.assertEquals(myErr.payload, myErrDecoded.payload);
+});

--- a/instance.ts
+++ b/instance.ts
@@ -1,0 +1,31 @@
+import { Codec } from "./common.ts";
+import { Fields, NativeRecord, record } from "./record.ts";
+
+export class Instance<Ctor extends new(...args: any[]) => any> extends Codec<InstanceType<Ctor>> {
+  constructor(
+    ctor: Ctor,
+    // TODO: this signature is `never` (doesn't affect outward-facing types... nevertheless, fix this)
+    ...fields: Fields<ConstructorParameters<Ctor>>
+  ) {
+    const rec = record(...fields);
+    super(
+      (value) => {
+        return rec._s(value as NativeRecord<Fields<ConstructorParameters<Ctor>>>);
+      },
+      (cursor, value) => {
+        rec._e(cursor, value as NativeRecord<Fields<ConstructorParameters<Ctor>>>);
+      },
+      (cursor) => {
+        return new ctor(...fields.map((field) => {
+          return (field[1] as any)._d(cursor);
+        }));
+      },
+    );
+  }
+}
+export const instance = <Ctor extends new(...args: any[]) => any>(
+  ctor: Ctor,
+  ...fields: Fields<ConstructorParameters<Ctor>>
+) => {
+  return new Instance(ctor, ...fields);
+};

--- a/mod.ts
+++ b/mod.ts
@@ -5,6 +5,7 @@ export * from "./compact.ts";
 export * from "./comparable_value_union.ts";
 export * from "./dummy.ts";
 export * from "./implicit_init_num_enum.ts";
+export * from "./instance.ts";
 export * from "./int.ts";
 export * from "./option.ts";
 export * from "./record.ts";

--- a/record.ts
+++ b/record.ts
@@ -5,6 +5,10 @@ export type Field<
   ValueCodec extends Codec = Codec,
 > = [Key, ValueCodec];
 
+export type Fields<T extends any[]> = T extends [] ? []
+  : T extends [infer E, ...infer Rest] ? [[PropertyKey, Codec<E>], ...Fields<Rest>]
+  : never;
+
 export type NativeRecord<Fields extends Field[]> = Fields extends [] ? {}
   : Fields extends [Field<infer K, infer V>, ...infer Rest]
     ? { [_ in K]: Native<V> } & (Rest extends Field[] ? NativeRecord<Rest> : {})


### PR DESCRIPTION
As described in the Readme:

Sometimes, you may want to instantiate a class with the decoded data / encode data from a class instance. In these situations, we can leverage the `instance` codec factory.

A common use case for `Instance` codecs is `Error` subtypes. Let's say we want to decode some data into the following `Error` subtype.

```ts
class MyError extends Error {
  constructor(
    code: string,
    message: string,
    payload: {
      a: string;
      b: number;
      c: boolean;
    },
  ) {}
}
```

We can do so as follows.

```ts
const codec = s.instance(
  MyError,
  ["code", s.str],
  ["message", s.str],
  [
    "payload",
    s.record(
      ["a", s.str],
      ["b", s.u8],
      ["c", s.bool],
    ),
  ],
);
```

We can now use this codec to encode and decode `MyError`.

```ts
const myError = new MyError(
  1,
  "At war with my Arch system config",
  {
    a: "a",
    b: 2,
    c: true,
  },
);

const encodedBytes = codec.encode(myError);
const decoded = codec.decode(encodedBytes);
```

> Note: executing an equality assertion between `myError` and `decoded` will fail, as they contain different stack traces.