### PR TITLE
Fix Design of Result Codec According to Instance Codec

### DIFF
--- a/result.ts
+++ b/result.ts
@@ -1,73 +1,14 @@
-import { Codec, Native } from "./common.ts";
+import { Codec } from "./common.ts";
+import { Instance } from "./instance.ts";
 import { Union } from "./union.ts";
 
-// TODO: extract `Instance` codec that allows instantiation of a supplied ctor
-
-export interface DataBearer<D> {
-  data: D;
-}
-
-export class Err<
-  ErrDataCodec extends Codec = Codec,
-  Ctor extends new(errData: Native<ErrDataCodec>) => Error & DataBearer<Native<ErrDataCodec>> = new(
-    err: Native<ErrDataCodec>,
-  ) => Error & Native<ErrDataCodec>,
-> extends Codec<InstanceType<Ctor>> {
-  constructor(
-    ctor: Ctor,
-    errDataCodec: ErrDataCodec,
-  ) {
-    super(
-      (value) => {
-        // TODO: confirm the `as` doesn't cause problems elsewhere
-        return errDataCodec._s(value.data);
-      },
-      (cursor, value) => {
-        // TODO: confirm the `as` doesn't cause problems elsewhere
-        return errDataCodec._e(cursor, value.data);
-      },
-      (cursor) => {
-        return new ctor(errDataCodec._d(cursor) as Native<ErrDataCodec>) as InstanceType<Ctor>;
-      },
-    );
-  }
-}
-
-export interface OkBearer<T = any> {
-  ok: T;
-}
-
-export class Ok<
-  ValueCodec extends Codec = Codec,
-  Ctor extends new(ok: Native<ValueCodec>) => OkBearer<Native<ValueCodec>> = new(
-    ok: Native<ValueCodec>,
-  ) => OkBearer<Native<ValueCodec>>,
-> extends Codec<InstanceType<Ctor>> {
-  constructor(
-    ctor: Ctor,
-    valueCodec: ValueCodec,
-  ) {
-    super(
-      (value) => {
-        return valueCodec._s(value.ok);
-      },
-      (cursor, value) => {
-        valueCodec._e(cursor, value.ok);
-      },
-      (cursor) => {
-        return new ctor(valueCodec._d(cursor)) as InstanceType<Ctor>;
-      },
-    );
-  }
-}
-
 export class Result<
-  Ok extends OkBearer,
+  Ok,
   Err extends Error,
 > extends Union<[Ok, Err]> {
   constructor(
     okCodec: Codec<Ok>,
-    errCodec: Codec<Err>,
+    errCodec: Instance<new(...args: any[]) => Err>,
   ) {
     super(
       (value) => {
@@ -78,3 +19,12 @@ export class Result<
     );
   }
 }
+export const result = <
+  Ok,
+  Err extends Error,
+>(
+  okCodec: Codec<Ok>,
+  errCodec: Instance<new(...args: any[]) => any>,
+): Result<Ok, Err> => {
+  return new Result(okCodec, errCodec);
+};


### PR DESCRIPTION
```ts
class MyError {
  constructor(readonly message: string) {}
}
const errorCodec = s.instance(MyError, ["message", s.str]);

const resultCodec = s.Result(errorCodec, s.str);

const encodedBytes = resultCodec.resultCodec(new MyError("Uh oh!"));
const decoded = resultCodec.decode(encodedBytes);

if (decoded instanceof Error) {
  decoded.message; // "Uh oh!"
} else {
  decoded; // type is `string`
}
```