### PR TITLE
fix: array codec factory typing

### DIFF
--- a/array.ts
+++ b/array.ts
@@ -58,6 +58,6 @@ export class Array<El> extends Codec<El[]> {
     );
   }
 }
-export const array = <ElCodec extends Codec>(elCodec: ElCodec): Array<ElCodec> => {
+export const array = <El>(elCodec: Codec<El>): Array<El> => {
   return new Array(elCodec);
 };


### PR DESCRIPTION
`array(str)` incorrectly produced a signature of `Codec<string>[]` –– this PR fixes that faulty signature