### PR TITLE
chore: remove `createAsyncCodec`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -107,7 +107,7 @@ While we recommend following this convention for consistency, you can, of course
 
 ## Asynchronous Encoding
 
-Some codecs require asynchronous encoding – namely `$.promise` and any custom codecs created with `createAsyncCodec`. Calling `.encode()` on a codec will throw if it or another codec it calls is asynchronous. In this case, you must call `.encodeAsync()` instead, which returns a `Promise<Uint8Array>`. You can call `.encodeAsync()` on any codec; if it is a synchronous codec, it will simply resolve immediately.
+Some codecs require asynchronous encoding. Calling `.encode()` on a codec will throw if it or another codec it calls is asynchronous. In this case, you must call `.encodeAsync()` instead, which returns a `Promise<Uint8Array>`. You can call `.encodeAsync()` on any codec; if it is a synchronous codec, it will simply resolve immediately.
 
 Asynchronous decoding is not supported.
 

--- a/codecs/promise.ts
+++ b/codecs/promise.ts
@@ -1,12 +1,14 @@
-import { Codec, createAsyncCodec } from "../common/mod.ts";
+import { Codec, createCodec } from "../common/mod.ts";
 
 export function promise<T>($value: Codec<T>): Codec<Promise<T>> {
-  return createAsyncCodec({
+  return createCodec({
     name: "$.promise",
     _metadata: [promise, $value],
     _staticSize: $value._staticSize,
-    async _encodeAsync(buffer, value) {
-      $value._encode(buffer, await value);
+    _encode(buffer, value) {
+      buffer.writeAsync($value._staticSize, async (buffer) => {
+        $value._encode(buffer, await value);
+      });
     },
     _decode(buffer) {
       return Promise.resolve($value._decode(buffer));


### PR DESCRIPTION
This wasn't used anywhere other than `$.promise`. Asynchronous encoding is still supported using `.writeAsync`.