### PR TITLE
chore: remove `$.union`

### DIFF
--- a/codecs/fixtures/union.rs
+++ b/codecs/fixtures/union.rs
@@ -1,22 +1,6 @@
 use parity_scale_codec::Encode;
 
 #[derive(Encode)]
-enum Primitive {
-  #[codec(index = 0)]
-  String(String),
-  /* skip number */
-  #[codec(index = 2)]
-  BigInt(u64),
-  #[codec(index = 3)]
-  Boolean(bool),
-  #[codec(index = 4)]
-  Undefined,
-  /* skip symbol */
-  #[codec(index = 6)]
-  Null,
-}
-
-#[derive(Encode)]
 enum Abc {
   A,
   B(String),
@@ -54,11 +38,6 @@ enum InterestingU8s {
 }
 
 crate::fixtures!(
-  Primitive::String("abc".to_string()),
-  Primitive::BigInt(1234567890),
-  Primitive::Boolean(true),
-  Primitive::Undefined,
-  Primitive::Null,
   Abc::A,
   Abc::B("HELLO".to_string()),
   Abc::C(255, 101010101),

--- a/codecs/test/__snapshots__/union.test.ts.snap
+++ b/codecs/test/__snapshots__/union.test.ts.snap
@@ -1,34 +1,5 @@
 export const snapshot = {};
 
-snapshot[`\$primitive "abc" 1`] = `
-00
-0c
-61
-62
-63
-`;
-
-snapshot[`\$primitive 1234567890n 1`] = `
-02
-d2
-02
-96
-49
-00
-00
-00
-00
-`;
-
-snapshot[`\$primitive true 1`] = `
-03
-01
-`;
-
-snapshot[`\$primitive undefined 1`] = `04`;
-
-snapshot[`\$primitive null 1`] = `06`;
-
 snapshot[`\$abc { _tag: "A" } 1`] = `00`;
 
 snapshot[`\$abc { _tag: "B", B: "HELLO" } 1`] = `

--- a/codecs/test/union.test.ts
+++ b/codecs/test/union.test.ts
@@ -2,32 +2,6 @@ import * as $ from "../../mod.ts";
 import { metadata } from "../../mod.ts";
 import { testCodec } from "../../test-util.ts";
 
-const $primitive = $.withMetadata(
-  metadata("$primitive"),
-  $.union(
-    (value) => {
-      return typeof value === "string"
-        ? 0
-        : typeof value === "bigint"
-        ? 2
-        : typeof value === "boolean"
-        ? 3
-        : value === undefined
-        ? 4
-        : 6;
-    },
-    {
-      0: $.str,
-      /* skip number */
-      2: $.u64,
-      3: $.bool,
-      4: $.dummy(undefined),
-      /* skip symbol */
-      6: $.dummy(null),
-    },
-  ),
-);
-
 const $abc = $.withMetadata(
   metadata("$abc"),
   $.taggedUnion("_tag", [
@@ -61,14 +35,6 @@ const names = [
 ] as const;
 
 const $names = $.withMetadata(metadata("$.stringUnion(names)"), $.stringUnion(names));
-
-testCodec($primitive, [
-  "abc",
-  1234567890n,
-  true,
-  undefined,
-  null,
-]);
 
 testCodec($abc, [
   { _tag: "A" },

--- a/examples/unions.eg.ts
+++ b/examples/unions.eg.ts
@@ -9,24 +9,6 @@ export const $myResult = $.result($.str, $myError);
 
 $myResult; // Codec<string | MyError>
 
-export const $strOrNum = $.union(
-  (value) => { // Discriminate
-    if (typeof value === "string") {
-      return 0;
-    } else if (typeof value === "number") {
-      return 1;
-    } else {
-      throw new Error("invalid");
-    }
-  },
-  [
-    $.str, // Member 0
-    $.u32, // Member 1
-  ],
-);
-
-$strOrNum; // Codec<string | number>
-
 export const $animal = $.taggedUnion("type", [
   ["dog", ["bark", $.str]],
   ["cat", ["purr", $.str]],


### PR DESCRIPTION
Isn't used at all outside of `$.taggedUnion`.

Drafted until #109 is merged.