### PR TITLE
feat: add assert method to codec

### DIFF
--- a/common/codec.ts
+++ b/common/codec.ts
@@ -129,7 +129,7 @@ export abstract class Codec<in out T> extends _Codec implements AnyCodec {
     return this._decode(buf)
   }
 
-  /** Asserts that the value is valid for this codec */
+  /** Requires the codec to have an explicit type annotation; if it doesn't, use `$.assert` instead. */
   assert(value: unknown): asserts value is T {
     assert(this, value)
   }

--- a/common/codec.ts
+++ b/common/codec.ts
@@ -93,7 +93,7 @@ export interface AnyCodec extends _Codec {
   encode(value: any): Uint8Array
   encodeAsync(value: any): Promise<Uint8Array>
   decode(array: Uint8Array): any
-  assert(value: any): void
+  assert(value: unknown): void
 }
 
 export abstract class Codec<in out T> extends _Codec implements AnyCodec {

--- a/common/codec.ts
+++ b/common/codec.ts
@@ -93,6 +93,7 @@ export interface AnyCodec extends _Codec {
   encode(value: any): Uint8Array
   encodeAsync(value: any): Promise<Uint8Array>
   decode(array: Uint8Array): any
+  assert(value: any): void
 }
 
 export abstract class Codec<in out T> extends _Codec implements AnyCodec {
@@ -127,8 +128,14 @@ export abstract class Codec<in out T> extends _Codec implements AnyCodec {
     const buf = new DecodeBuffer(array)
     return this._decode(buf)
   }
+
+  /** Asserts that the value is valid for this codec */
+  assert(value: unknown): asserts value is T {
+    assert(this, value)
+  }
 }
 
+/** Asserts that the value is valid for the specified codec */
 export function assert<T>(codec: Codec<T>, value: unknown): asserts value is T {
   codec._assert(new AssertState(value))
 }

--- a/examples/assertions.eg.ts
+++ b/examples/assertions.eg.ts
@@ -1,0 +1,12 @@
+import * as $ from "../mod.ts"
+
+// using `$.assert` (no explicit typing required)
+const a: unknown = 1
+$.assert($.u8, a)
+a
+
+// using `Codec.assert` (explicit typing required)
+const b: unknown = 2
+const u8: $.Codec<number> = $.u8
+u8.assert(b)
+b


### PR DESCRIPTION
```ts
// using `$.assert` (no explicit typing required)
const a: unknown = 1
$.assert($.u8, a)
a // `number`

// using `Codec.assert` (explicit typing required)
const b: unknown = 2
const u8: $.Codec<number> = $.u8
u8.assert(b)
b // `number`
```