### PR TITLE
feat: enable specificity of empty option value

### DIFF
--- a/codecs/option.ts
+++ b/codecs/option.ts
@@ -1,22 +1,23 @@
 import { Codec, createCodec, metadata, ScaleDecodeError } from "../common/mod.ts"
 
-export function option<Some>($some: Codec<Some>): Codec<Some | undefined> {
+export function option<T>($some: Codec<T>): Codec<T | undefined>
+export function option<T, U>($some: Codec<T>, none: U): Codec<T | U>
+export function option<T, U>($some: Codec<T>, none?: U): Codec<T | U> {
   if ($some._metadata.some((x) => x.factory === option)) {
     throw new Error("Nested option codec will not roundtrip correctly")
   }
   return createCodec({
-    _metadata: metadata("$.option", option, $some),
+    _metadata: metadata("$.option", option<T, U>, $some, none!),
     _staticSize: 1 + $some._staticSize,
     _encode(buffer, value) {
-      if ((buffer.array[buffer.index++] = +(value !== undefined))) {
-        $some._encode(buffer, value!)
+      if ((buffer.array[buffer.index++] = +(value !== none))) {
+        $some._encode(buffer, value! as T)
       }
     },
     _decode(buffer) {
       switch (buffer.array[buffer.index++]) {
-        case 0: {
-          return undefined
-        }
+        case 0:
+          return none as U
         case 1: {
           const value = $some._decode(buffer)
           if (value === undefined) {
@@ -24,13 +25,12 @@ export function option<Some>($some: Codec<Some>): Codec<Some | undefined> {
           }
           return value
         }
-        default: {
+        default:
           throw new ScaleDecodeError(this, buffer, "Option discriminant neither 0 nor 1")
-        }
       }
     },
     _assert(assert) {
-      if (assert.value === undefined) return
+      if (assert.value === none) return
       $some._assert(assert)
     },
   })

--- a/codecs/test/__snapshots__/deferred.test.ts.snap
+++ b/codecs/test/__snapshots__/deferred.test.ts.snap
@@ -1,14 +1,23 @@
 export const snapshot = {};
 
-snapshot[`\$0 = \$.option(\$.object(\$.field("val", \$.u8), \$.field("next", \$.deferred(() => \$0)))) undefined 1`] = `00`;
+snapshot[`\$0 = \$.option(
+  \$.object(\$.field("val", \$.u8), \$.field("next", \$.deferred(() => \$0))),
+  undefined
+) undefined 1`] = `00`;
 
-snapshot[`\$0 = \$.option(\$.object(\$.field("val", \$.u8), \$.field("next", \$.deferred(() => \$0)))) { val: 1, next: undefined } 1`] = `
+snapshot[`\$0 = \$.option(
+  \$.object(\$.field("val", \$.u8), \$.field("next", \$.deferred(() => \$0))),
+  undefined
+) { val: 1, next: undefined } 1`] = `
 01
 01
 00
 `;
 
-snapshot[`\$0 = \$.option(\$.object(\$.field("val", \$.u8), \$.field("next", \$.deferred(() => \$0)))) { val: 1, next: { val: 2, next: { val: 3, next: undefined } } } 1`] = `
+snapshot[`\$0 = \$.option(
+  \$.object(\$.field("val", \$.u8), \$.field("next", \$.deferred(() => \$0))),
+  undefined
+) { val: 1, next: { val: 2, next: { val: 3, next: undefined } } } 1`] = `
 01
 01
 01
@@ -18,10 +27,22 @@ snapshot[`\$0 = \$.option(\$.object(\$.field("val", \$.u8), \$.field("next", \$.
 00
 `;
 
-snapshot[`\$0 = \$.option(\$.object(\$.field("val", \$.u8), \$.field("next", \$.deferred(() => \$0)))) invalid null 1`] = `ScaleAssertError: value == null`;
+snapshot[`\$0 = \$.option(
+  \$.object(\$.field("val", \$.u8), \$.field("next", \$.deferred(() => \$0))),
+  undefined
+) invalid null 1`] = `ScaleAssertError: value == null`;
 
-snapshot[`\$0 = \$.option(\$.object(\$.field("val", \$.u8), \$.field("next", \$.deferred(() => \$0)))) invalid { val: 1, next: null } 1`] = `ScaleAssertError: value.next == null`;
+snapshot[`\$0 = \$.option(
+  \$.object(\$.field("val", \$.u8), \$.field("next", \$.deferred(() => \$0))),
+  undefined
+) invalid { val: 1, next: null } 1`] = `ScaleAssertError: value.next == null`;
 
-snapshot[`\$0 = \$.option(\$.object(\$.field("val", \$.u8), \$.field("next", \$.deferred(() => \$0)))) invalid { val: 1, next: { val: -1, next: undefined } } 1`] = `ScaleAssertError: value.next.val < 0`;
+snapshot[`\$0 = \$.option(
+  \$.object(\$.field("val", \$.u8), \$.field("next", \$.deferred(() => \$0))),
+  undefined
+) invalid { val: 1, next: { val: -1, next: undefined } } 1`] = `ScaleAssertError: value.next.val < 0`;
 
-snapshot[`\$0 = \$.option(\$.object(\$.field("val", \$.u8), \$.field("next", \$.deferred(() => \$0)))) invalid { val: 1, next: { val: 2, next: { val: 3, next: { val: -1, next: undefined } } } } 1`] = `ScaleAssertError: value.next.next.next.val < 0`;
+snapshot[`\$0 = \$.option(
+  \$.object(\$.field("val", \$.u8), \$.field("next", \$.deferred(() => \$0))),
+  undefined
+) invalid { val: 1, next: { val: 2, next: { val: 3, next: { val: -1, next: undefined } } } } 1`] = `ScaleAssertError: value.next.next.next.val < 0`;

--- a/codecs/test/__snapshots__/never.test.ts.snap
+++ b/codecs/test/__snapshots__/never.test.ts.snap
@@ -1,11 +1,11 @@
 export const snapshot = {};
 
-snapshot[`\$.option(\$.never) undefined 1`] = `00`;
+snapshot[`\$.option(\$.never, undefined) undefined 1`] = `00`;
 
 snapshot[`\$.never invalid null 1`] = `ScaleAssertError: value: Cannot validate \$.never`;
 
 snapshot[`\$.never invalid 0 1`] = `ScaleAssertError: value: Cannot validate \$.never`;
 
-snapshot[`\$.option(\$.never) invalid null 1`] = `ScaleAssertError: value: Cannot validate \$.never`;
+snapshot[`\$.option(\$.never, undefined) invalid null 1`] = `ScaleAssertError: value: Cannot validate \$.never`;
 
-snapshot[`\$.option(\$.never) invalid 0 1`] = `ScaleAssertError: value: Cannot validate \$.never`;
+snapshot[`\$.option(\$.never, undefined) invalid 0 1`] = `ScaleAssertError: value: Cannot validate \$.never`;

--- a/codecs/test/__snapshots__/option.test.ts.snap
+++ b/codecs/test/__snapshots__/option.test.ts.snap
@@ -1,6 +1,6 @@
 export const snapshot = {};
 
-snapshot[`\$.option(\$.str) "HELLO!" 1`] = `
+snapshot[`\$.option(\$.str, undefined) "HELLO!" 1`] = `
 01
 18
 48
@@ -11,12 +11,12 @@ snapshot[`\$.option(\$.str) "HELLO!" 1`] = `
 21
 `;
 
-snapshot[`\$.option(\$.u8) 1 1`] = `
+snapshot[`\$.option(\$.u8, undefined) 1 1`] = `
 01
 01
 `;
 
-snapshot[`\$.option(\$.u32) 4294967295 1`] = `
+snapshot[`\$.option(\$.u32, undefined) 4294967295 1`] = `
 01
 ff
 ff
@@ -24,16 +24,33 @@ ff
 ff
 `;
 
-snapshot[`\$.option(\$.bool) true 1`] = `
+snapshot[`\$.option(\$.bool, undefined) true 1`] = `
 01
 01
 `;
 
-snapshot[`\$.option(\$.bool) false 1`] = `
+snapshot[`\$.option(\$.bool, undefined) false 1`] = `
 01
 00
 `;
 
-snapshot[`\$.option(\$.bool) undefined 1`] = `00`;
+snapshot[`\$.option(\$.bool, undefined) undefined 1`] = `00`;
 
-snapshot[`\$.option(\$.bool) invalid 123 1`] = `ScaleAssertError: typeof value !== "boolean"`;
+snapshot[`\$.option(\$.str, null) "hi" 1`] = `
+01
+08
+68
+69
+`;
+
+snapshot[`\$.option(\$.str, null) "low" 1`] = `
+01
+0c
+6c
+6f
+77
+`;
+
+snapshot[`\$.option(\$.str, null) null 1`] = `00`;
+
+snapshot[`\$.option(\$.bool, undefined) invalid 123 1`] = `ScaleAssertError: typeof value !== "boolean"`;

--- a/codecs/test/__snapshots__/tuple.test.ts.snap
+++ b/codecs/test/__snapshots__/tuple.test.ts.snap
@@ -468,7 +468,7 @@ ff
 ff
 `;
 
-snapshot[`\$.tuple(\$.str, \$.i16, \$.option(\$.u16)) [ "GOODBYE!", 2, 101 ] 1`] = `
+snapshot[`\$.tuple(\$.str, \$.i16, \$.option(\$.u16, undefined)) [ "GOODBYE!", 2, 101 ] 1`] = `
 20
 47
 4f

--- a/codecs/test/option.test.ts
+++ b/codecs/test/option.test.ts
@@ -5,6 +5,7 @@ testCodec($.option($.str), ["HELLO!"])
 testCodec($.option($.u8), [1])
 testCodec($.option($.u32), [2 ** 32 - 1])
 testCodec($.option($.bool), [true, false, undefined])
+testCodec($.option($.str, null), ["hi", "low", null])
 
 testInvalid($.option($.bool), [123])
 

--- a/common/test/inspect.test.ts
+++ b/common/test/inspect.test.ts
@@ -15,13 +15,19 @@ Deno.test("inspect", () => {
   assertEquals(Deno.inspect($.array($.tuple($.u8, $.str))), "$.array($.tuple($.u8, $.str))")
   assertEquals(
     Deno.inspect($linkedList),
-    `$0 = $.option($.object($.field("val", $.u8), $.field("next", $.deferred(() => $0))))`,
+    `$0 = $.option(
+  $.object($.field("val", $.u8), $.field("next", $.deferred(() => $0))),
+  undefined
+)`,
   )
   assertEquals(
     Deno.inspect($.array($linkedList)),
     `
 $.array(
-  $0 = $.option($.object($.field("val", $.u8), $.field("next", $.deferred(() => $0))))
+  $0 = $.option(
+    $.object($.field("val", $.u8), $.field("next", $.deferred(() => $0))),
+    undefined
+  )
 )
     `.trim(),
   )


### PR DESCRIPTION
These changes enable specificity of a value to use in the case that the option is none.

```ts
$.option($some, null);
```

Note: the none value is optional. Ie. `$.option($some)` remains valid (and is equivalent to `$.option($some, undefined)`).